### PR TITLE
Define default transition and add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# Editorconfig: https://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 
 [*]
 charset = utf-8
-indent_style = tab
+indent_style = space
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/src/components/Course/styled.js
+++ b/src/components/Course/styled.js
@@ -2,7 +2,7 @@ import Img from 'gatsby-image'
 import styled from 'styled-components'
 import media from 'styled-media-query'
 
-import transitions from '../../styles/transition';
+import transitions from '../../styles/transitions';
 
 export const ImageWrapper = styled(Img)`
   border-radius: 50%;

--- a/src/components/Course/styled.js
+++ b/src/components/Course/styled.js
@@ -2,6 +2,8 @@ import Img from 'gatsby-image'
 import styled from 'styled-components'
 import media from 'styled-media-query'
 
+import transitions from '../../styles/transition';
+
 export const ImageWrapper = styled(Img)`
   border-radius: 50%;
   display: flex;
@@ -37,7 +39,7 @@ export const CourseLink = styled.a`
   color: var(--texts);
   display: flex;
   text-decoration: none;
-  transition: color 0.5s;
+  transition: ${transitions.COLOR};
 
   body#card & {
     background-color: var(--background);

--- a/src/components/Layout/styled.js
+++ b/src/components/Layout/styled.js
@@ -1,6 +1,8 @@
 import styled from 'styled-components'
 import media from 'styled-media-query'
 
+import transitions from '../../styles/transitions'
+
 export const LayoutWrapper = styled.section`
   display: flex;
 
@@ -14,7 +16,7 @@ export const LayoutMain = styled.main`
   background: var(--background);
   min-height: 100vh;
   padding: 0 3.75rem 0 20rem;
-  transition: background 0.5s, color 0.5s;
+  transition: ${transitions.DEFAULT};
   width: 100%;
 
   body#card & {

--- a/src/components/MenuBar/styled.js
+++ b/src/components/MenuBar/styled.js
@@ -57,7 +57,7 @@ export const MenuBarItem = styled.span`
   padding: 1.1rem;
   position: relative;
   width: 3.75rem;
-  transition: color 0.5s;
+  transition: ${transitions.COLOR};
 
   &.light {
     color: #d4d400;

--- a/src/components/MenuBar/styled.js
+++ b/src/components/MenuBar/styled.js
@@ -3,6 +3,8 @@ import media from 'styled-media-query'
 
 import AniLink from 'gatsby-plugin-transition-link/AniLink'
 
+import transitions from '../../styles/transitions'
+
 export const MenuBarWrapper = styled.aside`
   align-items: center;
   background: var(--mediumBackground);
@@ -15,6 +17,7 @@ export const MenuBarWrapper = styled.aside`
   position: fixed;
   right: 0;
   width: 3.75rem;
+  transition: ${transitions.DEFAULT};
 
   ${media.lessThan('large')`
     border-top: 1px solid var(--borders);

--- a/src/components/Pagination/styled.js
+++ b/src/components/Pagination/styled.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import media from 'styled-media-query'
 
-import transitions from '../../styles/transition';
+import transitions from '../../styles/transitions';
 
 export const PaginationWrapper = styled.section`
   align-items: center;

--- a/src/components/Pagination/styled.js
+++ b/src/components/Pagination/styled.js
@@ -1,6 +1,8 @@
 import styled from 'styled-components'
 import media from 'styled-media-query'
 
+import transitions from '../../styles/transition';
+
 export const PaginationWrapper = styled.section`
   align-items: center;
   border-top: 1px solid var(--borders);
@@ -17,7 +19,7 @@ export const PaginationWrapper = styled.section`
   a {
     color: var(--texts);
     text-decoration: none;
-    transition: color 0.5s;
+    transition: ${transitions.COLOR};
 
     &:hover {
       color: var(--highlight);

--- a/src/components/Post/styled.js
+++ b/src/components/Post/styled.js
@@ -2,6 +2,8 @@ import styled from 'styled-components'
 import media from 'styled-media-query'
 import AniLink from 'gatsby-plugin-transition-link/AniLink'
 
+import transitions from '../../styles/transitions';
+
 export const PostWrapper = styled.section`
   align-items: center;
   border-bottom: 1px solid var(--borders);
@@ -27,7 +29,7 @@ export const PostLink = styled(AniLink)`
   color: var(--texts);
   display: flex;
   text-decoration: none;
-  transition: color 0.5s;
+  transition: ${transitions.COLOR};
 
   body#card & {
     background-color: var(--background);

--- a/src/components/RecommendedPosts/styled.js
+++ b/src/components/RecommendedPosts/styled.js
@@ -2,6 +2,8 @@ import styled from 'styled-components'
 import media from 'styled-media-query'
 import AniLink from 'gatsby-plugin-transition-link/AniLink'
 
+import transitions from '../../styles/transitions';
+
 export const RecommendedWrapper = styled.section`
   border-bottom: 1px solid var(--borders);
   border-top: 1px solid var(--borders);
@@ -16,7 +18,7 @@ export const RecommendedLink = styled(AniLink)`
   display: flex;
   padding: 3rem;
   text-decoration: none;
-  transition: background 0.5s;
+  transition: ${transitions.BACKGROUND};
   width: 50%;
 
   ${media.lessThan('large')`

--- a/src/components/Sidebar/styled.js
+++ b/src/components/Sidebar/styled.js
@@ -1,6 +1,8 @@
 import styled from 'styled-components'
 import media from 'styled-media-query'
 
+import transitions from '../../styles/transitions'
+
 export const SidebarContainer = styled.aside`
   align-items: center;
   border-right: 1px solid var(--borders);
@@ -13,6 +15,7 @@ export const SidebarContainer = styled.aside`
   text-align: center;
   width: 20rem;
   z-index: 9999;
+  transition: ${transitions.DEFAULT};
 
   ${media.lessThan('large')`
     align-items: flex-start;

--- a/src/components/Sidebar/styled.js
+++ b/src/components/Sidebar/styled.js
@@ -32,7 +32,7 @@ export const SidebarContainer = styled.aside`
   a {
     color: var(--texts);
     text-decoration: none;
-    transition: color 0.5s;
+    transition: ${transitions.COLOR};
 
     &:hover {
       color: var(--highlight);

--- a/src/styles/transitions.js
+++ b/src/styles/transitions.js
@@ -1,10 +1,10 @@
-const defaultTiming = '0.5s';
-const bgTransition = `background ${defaultTiming}`;
-const colorTransition = `color ${defaultTiming}`;
-const defaultTransition = `${bgTransition}, ${colorTransition}`;
+const defaultTiming = '0.5s'
+const bgTransition = `background ${defaultTiming}`
+const colorTransition = `color ${defaultTiming}`
+const defaultTransition = `${bgTransition}, ${colorTransition}`
 
 export default {
-    DEFAULT: defaultTransition,
-    COLOR: colorTransition,
-    BACKGROUND: bgTransition
-};
+  DEFAULT: defaultTransition,
+  COLOR: colorTransition,
+  BACKGROUND: bgTransition
+}

--- a/src/styles/transitions.js
+++ b/src/styles/transitions.js
@@ -1,0 +1,10 @@
+const defaultTiming = '0.5s';
+const bgTransition = `background ${defaultTiming}`;
+const colorTransition = `color ${defaultTiming}`;
+const defaultTransition = `${bgTransition}, ${colorTransition}`;
+
+export default {
+    DEFAULT: defaultTransition,
+    COLOR: colorTransition,
+    BACKGROUND: bgTransition
+};


### PR DESCRIPTION
There is a slightly difference between the sidebars and the main content (post) transitions.

As you can see at:
![Screen Recording 2019-07-23 at 13 37 35](https://user-images.githubusercontent.com/13336905/61730811-8dd44b00-ad50-11e9-8d4d-9324c074b625.gif)

This PR creates some default transitions and applies it at the sidebars and main content containers.

Giving them a default transition like:
![Screen Recording 2019-07-23 at 13 37 10](https://user-images.githubusercontent.com/13336905/61730885-b1979100-ad50-11e9-8c64-2b3256bfcb2e.gif)
