### PR TITLE
Fix next post when is only child

### DIFF
--- a/src/components/RecommendedPosts/styled.js
+++ b/src/components/RecommendedPosts/styled.js
@@ -39,6 +39,11 @@ export const RecommendedLink = styled(AniLink)`
     justify-content: flex-end;
   }
 
+  &.next:only-child {
+    margin-left: auto;
+    border-left: 1px solid var(--borders);
+  }
+
   &.previous:before {
     content: '\\2190';
     margin-right: 0.5rem;


### PR DESCRIPTION
Nos posts recomendados, quando não há um "next", o "previous" se comporta assim:

![Previous Post](https://user-images.githubusercontent.com/3433276/68731773-f53c3200-05af-11ea-8cc4-9e5d28e537cd.png)

Porém, quando não há um "previous", o "next" fica desajustado dessa forma:

![Next Post](https://user-images.githubusercontent.com/3433276/68731851-37657380-05b0-11ea-91d9-686efc86f371.png)

Esse pull request faz com que o "next" se comporte de maneira coerente quando não há post anterior:

![Next Post Fixed](https://user-images.githubusercontent.com/3433276/68732002-bce92380-05b0-11ea-8180-d50f54adfdbd.png)


