### PR TITLE
Update link (pasta de include)

### DIFF
--- a/posts/2018-03-20-perfomance-web-critical-css-e-jekyll.md
+++ b/posts/2018-03-20-perfomance-web-critical-css-e-jekyll.md
@@ -83,7 +83,7 @@ Como sabem, meu blog é feito em Jekyll desde o primeiro dia e eu escrevi como f
 - Post.css (necessário para a página de posts)
 - Minimal.css (necessário para as páginas de about/tags/series)
 
-Se você utilizar o Sass padrão no Jekyll, também é bem simples, basta criar os arquivos separados e importar os partials, que são iniciados com o `_` como `_cards.sass`. O importante é que você precisa mandar gerar os arquivos css finais dentro da pasta `includes`, pois assim, você consegue incluir o css como se fosse um arquivo de texto comum, ou seja, um inline css. Você pode olhar minha [pasta de includes](https://github.com/willianjusten/willianjusten.com.br/tree/master/_includes) do blog, que verá os arquivos de css lá.
+Se você utilizar o Sass padrão no Jekyll, também é bem simples, basta criar os arquivos separados e importar os partials, que são iniciados com o `_` como `_cards.sass`. O importante é que você precisa mandar gerar os arquivos css finais dentro da pasta `includes`, pois assim, você consegue incluir o css como se fosse um arquivo de texto comum, ou seja, um inline css. Você pode olhar minha [pasta de includes](https://github.com/willianjusten/willianjusten.com.br/tree/ecde3bd2481c24889932e1abaa5900a68cdc7769/_includes) do blog, que verá os arquivos de css lá.
 
 Depois dos arquivos já no `includes`, você vai adicionar o css nos templates, exemplo:
 


### PR DESCRIPTION
O link ficou quebra depois que fez a migração do template para o Gatsby.
Inseri um link do ultimo commit de quando o blog ainda usava Jekyll.