### PR TITLE
Remove accents from slug on post publish

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -7,6 +7,9 @@ backend:
 media_folder: static/assets/img
 public_folder: /assets/img
 publish_mode: editorial_workflow
+slug:
+  encoding: 'ascii'
+  clean_accents: true
 
 collections:
   - name: posts # Used in routes, e.g. /admin/collections/blog


### PR DESCRIPTION
Eu vi na pergunta de id: 11324994 do seu curso que você estava criando as postagens e editando novamente para remover acentos de um slug, gerando retrabalho. Desse jeito, isso não é mais preciso.

btw, da uma olhada na minha pergunta sobre problemas com cache lá também :)