### PR TITLE
Remove duplicated property from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@ root = true
 
 [*]
 charset = utf-8
-indent_style = space
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true


### PR DESCRIPTION
The `indent_style = space` was duplicated.